### PR TITLE
Fixed issue where this plugin fails for HTTPS mesos / marathon users

### DIFF
--- a/lib/MarathonEventListener.js
+++ b/lib/MarathonEventListener.js
@@ -75,7 +75,8 @@ MarathonEventListener.prototype.subscribe = function () {
         url = self.options.marathonProtocol + "://" + self.options.marathonUrl + ":" + self.options.marathonPort+"/v2/events";
 
     // Create EventSource for Marathon /v2/events endpoint
-    var es = new EventSource(url);
+    var eventSourceInitDict = {rejectUnauthorized: false};
+    var es = new EventSource(url, eventSourceInitDict);
 
     es.on("open", function () {
         self.emit("connected", { "timestamp": ((new Date().getTime())/1000) })


### PR DESCRIPTION
At Vivint we are running marathon with HTTPS & things were failing for us until we made this change. Anyone using HTTPS will have the same issue, so I am submitting this PR.